### PR TITLE
TG 1.2.0 + Make patching less dumb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 paradise-rust-g
+tg-rust-g

--- a/README.MD
+++ b/README.MD
@@ -2,11 +2,11 @@
 
 This repository holds ParadiseSS13 modifications of [rust-g](https://github.com/tgstation/rust-g) libraries from /tg/station.
 
-This works by keeping an up-to-date copy of /tg/station's code, and a folder of Paradise patches to be applied. This reduces our need for major reworks to code, as we can just use patches to achieve what we need without cluttering the main tree.
+This works by keeping a folder of Paradise patches to be applied, and applies it to a specific version tag of tg's rust-g. This reduces our need for major reworks to code, as we can just use patches to achieve what we need without cluttering the main tree.
 
 ## License
 
-The license for RUST-G itself can be found inside the `tg-rust-g` directory. Code for the Paradise modifications falls under the same license.
+The license for RUST-G itself can be found on tg's repo. Code for the Paradise modifications falls under the same license.
 
 ## How to (Compiling)
 
@@ -16,7 +16,7 @@ The license for RUST-G itself can be found inside the `tg-rust-g` directory. Cod
     - To build on windows, run `cargo build --release --all-features --target=i686-pc-windows-msvc`. This will generate a 32-bit `.dll` file that is compatible with BYOND.
     - To build on linux, run `cargo build --release --all-features --target=i686-unknown-linux-gnu`. This will generate a 32-bit `.so` file that is compatible with BYOND.
 
-If you are still stuck, check `tg-rust-g/README.md` for more detailed instructions.
+If you are still stuck, check tg's README. for more detailed instructions.
 
 ## How to (Developing)
 

--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 basedir=`pwd`
-tg_tag="1.1.0"
+tg_tag="1.2.0"
 
 echo "Checking for TG rust-g repo.."
 if [ ! -d "./tg-rust-g" ] 

--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 
-PS1="$"
 basedir=`pwd`
-echo "Rebuilding projects.... "
+tg_tag="1.1.0"
+
+echo "Checking for TG rust-g repo.."
+if [ ! -d "./tg-rust-g" ] 
+then
+    echo "TG rust-g does not exist locally. Cloning..."
+    git clone https://github.com/tgstation/rust-g.git tg-rust-g
+fi
+
+echo "Setting up project... "
+
+cd "$basedir/tg-rust-g"
+git reset --hard $tg_tag
 
 apply_patch() {
     what=$1

--- a/paradise-rust-g-patches/0001-Paradise-Version-Changes.patch
+++ b/paradise-rust-g-patches/0001-Paradise-Version-Changes.patch
@@ -1,33 +1,37 @@
-From 6ccf0ab4e818be9b0916b27858a9e0e5fc56c204 Mon Sep 17 00:00:00 2001
+From 124eccba73fa986f9d9ceffa7a8a69bd97eae218 Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Wed, 13 Oct 2021 22:04:30 +0100
 Subject: [PATCH] Paradise Version Changes
 
 
 diff --git a/Cargo.lock b/Cargo.lock
-index c79b9e7..15922c1 100644
+index ab158a2..f77d99f 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -1999,7 +1999,7 @@ dependencies = [
  
  [[package]]
  name = "rust-g"
--version = "1.0.2"
-+version = "1.0.2-P"
+-version = "1.2.0"
++version = "1.2.0-P"
  dependencies = [
   "aho-corasick",
   "base64",
 diff --git a/Cargo.toml b/Cargo.toml
-index 95d6d1a..780a84c 100644
+index 121c252..b2166a7 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -1,11 +1,11 @@
+@@ -1,15 +1,15 @@
  [package]
  name = "rust-g"
  edition = "2021"
--version = "1.0.2"
-+version = "1.0.2-P"
- authors = ["Bjorn Neergaard <bjorn@neersighted.com>", "Tad Hardesty <tad@platymuus.com>", "rust-g maintainer team"]
+-version = "1.2.0"
++version = "1.2.0-P"
+ authors = [
+     "Bjorn Neergaard <bjorn@neersighted.com>",
+     "Tad Hardesty <tad@platymuus.com>",
+     "rust-g maintainer team",
+ ]
 -repository = "https://github.com/tgstation/rust-g"
 +repository = "https://github.com/ParadiseSS13/rust-g"
  license = "MIT"
@@ -37,5 +41,5 @@ index 95d6d1a..780a84c 100644
  [lib]
  crate-type = ["cdylib"]
 -- 
-2.17.1
+2.35.2.windows.1
 

--- a/paradise-rust-g-patches/0001-Paradise-Version-Changes.patch
+++ b/paradise-rust-g-patches/0001-Paradise-Version-Changes.patch
@@ -1,41 +1,41 @@
-From ab1d942ac45e1b14ffaa13c79e2a44e5c2d2f54c Mon Sep 17 00:00:00 2001
+From 6ccf0ab4e818be9b0916b27858a9e0e5fc56c204 Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Wed, 13 Oct 2021 22:04:30 +0100
 Subject: [PATCH] Paradise Version Changes
 
 
 diff --git a/Cargo.lock b/Cargo.lock
-index cd4001f..85313cc 100644
+index c79b9e7..15922c1 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1544,7 +1544,7 @@ dependencies = [
+@@ -1999,7 +1999,7 @@ dependencies = [
  
  [[package]]
  name = "rust-g"
--version = "0.6.0"
-+version = "0.6.0-P"
+-version = "1.0.2"
++version = "1.0.2-P"
  dependencies = [
   "aho-corasick",
-  "base64 0.13.0",
+  "base64",
 diff --git a/Cargo.toml b/Cargo.toml
-index 1cbe8f5..68a7029 100644
+index 95d6d1a..780a84c 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -1,11 +1,11 @@
  [package]
  name = "rust-g"
- edition = "2018"
--version = "0.6.0"
-+version = "0.6.0-P"
- authors = ["Bjorn Neergaard <bjorn@neersighted.com>"]
+ edition = "2021"
+-version = "1.0.2"
++version = "1.0.2-P"
+ authors = ["Bjorn Neergaard <bjorn@neersighted.com>", "Tad Hardesty <tad@platymuus.com>", "rust-g maintainer team"]
 -repository = "https://github.com/tgstation/rust-g"
 +repository = "https://github.com/ParadiseSS13/rust-g"
- license-file = "LICENSE"
+ license = "MIT"
 -description = "Offloaded task library for the /tg/ Space Station 13 codebase"
-+description = "Offloaded task library for the ParadiseSS13 Space Station 13 codebase"
++description = "Offloaded task library for the ParadiseSS13 Space Station 13 codebase - Adapted from tgstation/rust-g"
  
  [lib]
  crate-type = ["cdylib"]
 -- 
-2.33.0.windows.2
+2.17.1
 

--- a/paradise-rust-g-patches/0002-Paradise-Logging-Changes.patch
+++ b/paradise-rust-g-patches/0002-Paradise-Logging-Changes.patch
@@ -1,4 +1,4 @@
-From 4a5eab77486dd2bccac8eb7e345cb9490db124e8 Mon Sep 17 00:00:00 2001
+From ecce1db2d967a128cc02baa73245d84009d9c7ec Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Wed, 13 Oct 2021 22:04:37 +0100
 Subject: [PATCH] Paradise Logging Changes
@@ -51,5 +51,5 @@ index 9bd019b..6722353 100644
  
          Ok(())
 -- 
-2.33.0.windows.2
+2.17.1
 

--- a/paradise-rust-g-patches/0002-Paradise-Logging-Changes.patch
+++ b/paradise-rust-g-patches/0002-Paradise-Logging-Changes.patch
@@ -1,17 +1,18 @@
-From ecce1db2d967a128cc02baa73245d84009d9c7ec Mon Sep 17 00:00:00 2001
+From a7d7ad5361239e00852692abc39c8404383290e4 Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Wed, 13 Oct 2021 22:04:37 +0100
 Subject: [PATCH] Paradise Logging Changes
 
 
 diff --git a/dmsrc/log.dm b/dmsrc/log.dm
-index d0380a5..f3be525 100644
+index 1faadc8..bbc8fe6 100644
 --- a/dmsrc/log.dm
 +++ b/dmsrc/log.dm
 @@ -1,2 +1,2 @@
--#define rustg_log_write(fname, text, format) call(RUST_G, "log_write")(fname, text, format)
-+#define rustg_log_write(fname, text) call(RUST_G, "log_write")(fname, text)
- /proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
+-#define rustg_log_write(fname, text, format) RUSTG_CALL(RUST_G, "log_write")(fname, text, format)
+-/proc/rustg_log_close_all() return RUSTG_CALL(RUST_G, "log_close_all")()
++#define rustg_log_write(fname, text) RUSTG_CALL(RUST_G, "log_write")(fname, text)
++/proc/rustg_log_close_all() return RUSTG_CALL(RUST_G, "log_close_all")()
 diff --git a/src/log.rs b/src/log.rs
 index 9bd019b..6722353 100644
 --- a/src/log.rs
@@ -51,5 +52,5 @@ index 9bd019b..6722353 100644
  
          Ok(())
 -- 
-2.17.1
+2.35.2.windows.1
 

--- a/paradise-rust-g-patches/0003-Paradise-API-Headers.patch
+++ b/paradise-rust-g-patches/0003-Paradise-API-Headers.patch
@@ -1,127 +1,202 @@
-From 11f3098faf5c6c388b6a24f548ef8cf2075b7321 Mon Sep 17 00:00:00 2001
+From 1302fc6aa9a84030c7f27a21f97311267d0b1691 Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Wed, 13 Oct 2021 22:11:10 +0100
 Subject: [PATCH] Paradise API Headers
 
 
+diff --git a/dmsrc/acreplace.dm b/dmsrc/acreplace.dm
+index 08107f0..3a8013a 100644
+--- a/dmsrc/acreplace.dm
++++ b/dmsrc/acreplace.dm
+@@ -1,3 +1,4 @@
++// Aho-Corasick Replace //
+ 
+ /**
+  * Sets up the Aho-Corasick automaton with its default options.
 diff --git a/dmsrc/cellularnoise.dm b/dmsrc/cellularnoise.dm
-index 2f48dd9..61303f7 100644
+index 2f48dd9..387d47a 100644
 --- a/dmsrc/cellularnoise.dm
 +++ b/dmsrc/cellularnoise.dm
 @@ -1,3 +1,5 @@
-+// Cellular Noise Operations //
++// Cellular Noise //
 +
  /**
   * This proc generates a cellular automata noise grid which can be used in procedural generation methods.
   *
+diff --git a/dmsrc/dbpnoise.dm b/dmsrc/dbpnoise.dm
+index 6cee0da..74575bf 100644
+--- a/dmsrc/dbpnoise.dm
++++ b/dmsrc/dbpnoise.dm
+@@ -1,3 +1,5 @@
++// Grid Perlin Noise //
++
+ /**
+  * This proc generates a grid of perlin-like noise
+  *
 diff --git a/dmsrc/dmi.dm b/dmsrc/dmi.dm
-index 6eed4e5..d3f271b 100644
+index 6eed4e5..8474661 100644
 --- a/dmsrc/dmi.dm
 +++ b/dmsrc/dmi.dm
-@@ -1,3 +1,4 @@
+@@ -1,3 +1,5 @@
 +// DMI Operations //
++
  #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
  #define rustg_dmi_create_png(path, width, height, data) call(RUST_G, "dmi_create_png")(path, width, height, data)
  #define rustg_dmi_resize_png(path, width, height, resizetype) call(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
 diff --git a/dmsrc/file.dm b/dmsrc/file.dm
-index e0c3033..9692a01 100644
+index cfc3258..1285c79 100644
 --- a/dmsrc/file.dm
 +++ b/dmsrc/file.dm
-@@ -1,3 +1,4 @@
+@@ -1,3 +1,5 @@
 +// File Operations //
++
  #define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
  #define rustg_file_exists(fname) call(RUST_G, "file_exists")(fname)
  #define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
 diff --git a/dmsrc/git.dm b/dmsrc/git.dm
-index 0dc5edc..b3b8a4b 100644
+index 0dc5edc..942e60f 100644
 --- a/dmsrc/git.dm
 +++ b/dmsrc/git.dm
-@@ -1,2 +1,3 @@
+@@ -1,2 +1,4 @@
 +// Git Operations //
++
  #define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
  #define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
 diff --git a/dmsrc/hash.dm b/dmsrc/hash.dm
-index 867b00e..673ee4e 100644
+index 867b00e..757d58e 100644
 --- a/dmsrc/hash.dm
 +++ b/dmsrc/hash.dm
-@@ -1,3 +1,4 @@
-+// Hashing Operations //
+@@ -1,3 +1,5 @@
++// Hashing Functions //
++
  #define rustg_hash_string(algorithm, text) call(RUST_G, "hash_string")(algorithm, text)
  #define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, fname)
  #define rustg_hash_generate_totp(seed) call(RUST_G, "generate_totp")(seed)
 diff --git a/dmsrc/http.dm b/dmsrc/http.dm
-index 93d964b..c756919 100644
+index 93d964b..c1ef9fd 100644
 --- a/dmsrc/http.dm
 +++ b/dmsrc/http.dm
-@@ -1,3 +1,4 @@
+@@ -1,3 +1,5 @@
 +// HTTP Operations //
++
  #define RUSTG_HTTP_METHOD_GET "get"
  #define RUSTG_HTTP_METHOD_PUT "put"
  #define RUSTG_HTTP_METHOD_DELETE "delete"
 diff --git a/dmsrc/jobs.dm b/dmsrc/jobs.dm
-index 499314b..c034d3c 100644
+index 499314b..501c20f 100644
 --- a/dmsrc/jobs.dm
 +++ b/dmsrc/jobs.dm
-@@ -1,3 +1,4 @@
-+// Jobs Subsystem Operations //
+@@ -1,3 +1,5 @@
++// Jobs Defines //
++
  #define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"
  #define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
  #define RUSTG_JOB_ERROR "JOB PANICKED"
 diff --git a/dmsrc/json.dm b/dmsrc/json.dm
-index 80a1853..013d2d1 100644
+index 80a1853..b33029a 100644
 --- a/dmsrc/json.dm
 +++ b/dmsrc/json.dm
-@@ -1 +1,2 @@
+@@ -1 +1,3 @@
 +// JSON Operations //
++
  #define rustg_json_is_valid(text) (call(RUST_G, "json_is_valid")(text) == "true")
 diff --git a/dmsrc/log.dm b/dmsrc/log.dm
-index 9faa561..8e2000a 100644
+index f3be525..4b113a2 100644
 --- a/dmsrc/log.dm
 +++ b/dmsrc/log.dm
-@@ -1,2 +1,3 @@
+@@ -1,2 +1,4 @@
 +// Logging Operations //
++
  #define rustg_log_write(fname, text) call(RUST_G, "log_write")(fname, text)
- /proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
+-/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
++/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
 diff --git a/dmsrc/noise.dm b/dmsrc/noise.dm
-index 6277a46..0192899 100644
+index 6277a46..935356d 100644
 --- a/dmsrc/noise.dm
 +++ b/dmsrc/noise.dm
-@@ -1 +1,2 @@
+@@ -1 +1,3 @@
 +// Noise Operations //
++
  #define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
+diff --git a/dmsrc/pathfinder.dm b/dmsrc/pathfinder.dm
+index be5ac80..292aec2 100644
+--- a/dmsrc/pathfinder.dm
++++ b/dmsrc/pathfinder.dm
+@@ -1,3 +1,5 @@
++// AStar Operations //
++
+ /**
+  * Register a list of nodes into a rust library. This list of nodes must have been serialized in a json.
+  * Node {// Index of this node in the list of nodes
+diff --git a/dmsrc/redis-pubsub.dm b/dmsrc/redis-pubsub.dm
+index 2524bb5..47e0694 100644
+--- a/dmsrc/redis-pubsub.dm
++++ b/dmsrc/redis-pubsub.dm
+@@ -1,3 +1,5 @@
++// Redis PubSub Operations //
++
+ #define RUSTG_REDIS_ERROR_CHANNEL "RUSTG_REDIS_ERROR_CHANNEL"
+ 
+ #define rustg_redis_connect(addr) call(RUST_G, "redis_connect")(addr)
 diff --git a/dmsrc/sql.dm b/dmsrc/sql.dm
-index d3bfc49..3f1d92f 100644
+index d3bfc49..803dd97 100644
 --- a/dmsrc/sql.dm
 +++ b/dmsrc/sql.dm
-@@ -1,3 +1,4 @@
-+// SQL Opeartions //
+@@ -1,3 +1,5 @@
++// SQL Operations //
++
  #define rustg_sql_connect_pool(options) call(RUST_G, "sql_connect_pool")(options)
  #define rustg_sql_query_async(handle, query, params) call(RUST_G, "sql_query_async")(handle, query, params)
  #define rustg_sql_query_blocking(handle, query, params) call(RUST_G, "sql_query_blocking")(handle, query, params)
+diff --git a/dmsrc/time.dm b/dmsrc/time.dm
+index 56e1b0c..5a76f67 100644
+--- a/dmsrc/time.dm
++++ b/dmsrc/time.dm
+@@ -1,3 +1,5 @@
++// Time Tracking Functions //
++
+ #define rustg_time_microseconds(id) text2num(call(RUST_G, "time_microseconds")(id))
+ #define rustg_time_milliseconds(id) text2num(call(RUST_G, "time_milliseconds")(id))
+ #define rustg_time_reset(id) call(RUST_G, "time_reset")(id)
 diff --git a/dmsrc/toml.dm b/dmsrc/toml.dm
-index e403301..46010e5 100644
+index c9a6338..e218b92 100644
 --- a/dmsrc/toml.dm
 +++ b/dmsrc/toml.dm
-@@ -1 +1,2 @@
+@@ -1,3 +1,5 @@
 +// TOML Operations //
- #define rustg_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
++
+ #define rustg_raw_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+ 
+ /proc/rustg_read_toml_file(path)
 diff --git a/dmsrc/unzip.dm b/dmsrc/unzip.dm
-index ce945b1..970d673 100644
+index ce945b1..d8be8b1 100644
 --- a/dmsrc/unzip.dm
 +++ b/dmsrc/unzip.dm
-@@ -1,2 +1,3 @@
-+// Unzip Operations //
+@@ -1,2 +1,4 @@
++// ZIP File Operations //
++
  #define rustg_unzip_download_async(url, unzip_directory) call(RUST_G, "unzip_download_async")(url, unzip_directory)
  #define rustg_unzip_check(job_id) call(RUST_G, "unzip_check")("[job_id]")
 diff --git a/dmsrc/url.dm b/dmsrc/url.dm
-index b56131b..5e59114 100644
+index b56131b..c83f8aa 100644
 --- a/dmsrc/url.dm
 +++ b/dmsrc/url.dm
-@@ -1,3 +1,4 @@
-+// URL Encoder/Decoder Operations //
+@@ -1,3 +1,5 @@
++// URL Operations //
++
  #define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
  #define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
  
+diff --git a/dmsrc/worleynoise.dm b/dmsrc/worleynoise.dm
+index 1ff347c..9864a5b 100644
+--- a/dmsrc/worleynoise.dm
++++ b/dmsrc/worleynoise.dm
+@@ -1,3 +1,5 @@
++// Worley Noise Operations //
++
+ /**
+  * This proc generates a noise grid using worley noise algorithm
+  *
 -- 
-2.33.0.windows.2
+2.17.1
 

--- a/paradise-rust-g-patches/0003-Paradise-API-Headers.patch
+++ b/paradise-rust-g-patches/0003-Paradise-API-Headers.patch
@@ -1,11 +1,11 @@
-From 1302fc6aa9a84030c7f27a21f97311267d0b1691 Mon Sep 17 00:00:00 2001
+From 1bac400d13a18fa69dacf7571513de3c7d70ad54 Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Wed, 13 Oct 2021 22:11:10 +0100
 Subject: [PATCH] Paradise API Headers
 
 
 diff --git a/dmsrc/acreplace.dm b/dmsrc/acreplace.dm
-index 08107f0..3a8013a 100644
+index ada138c..6817453 100644
 --- a/dmsrc/acreplace.dm
 +++ b/dmsrc/acreplace.dm
 @@ -1,3 +1,4 @@
@@ -14,7 +14,7 @@ index 08107f0..3a8013a 100644
  /**
   * Sets up the Aho-Corasick automaton with its default options.
 diff --git a/dmsrc/cellularnoise.dm b/dmsrc/cellularnoise.dm
-index 2f48dd9..387d47a 100644
+index 2828fdc..9561032 100644
 --- a/dmsrc/cellularnoise.dm
 +++ b/dmsrc/cellularnoise.dm
 @@ -1,3 +1,5 @@
@@ -24,7 +24,7 @@ index 2f48dd9..387d47a 100644
   * This proc generates a cellular automata noise grid which can be used in procedural generation methods.
   *
 diff --git a/dmsrc/dbpnoise.dm b/dmsrc/dbpnoise.dm
-index 6cee0da..74575bf 100644
+index 2b3914d..702c5cf 100644
 --- a/dmsrc/dbpnoise.dm
 +++ b/dmsrc/dbpnoise.dm
 @@ -1,3 +1,5 @@
@@ -34,46 +34,48 @@ index 6cee0da..74575bf 100644
   * This proc generates a grid of perlin-like noise
   *
 diff --git a/dmsrc/dmi.dm b/dmsrc/dmi.dm
-index 6eed4e5..8474661 100644
+index f5d5fe5..d04b0d1 100644
 --- a/dmsrc/dmi.dm
 +++ b/dmsrc/dmi.dm
 @@ -1,3 +1,5 @@
 +// DMI Operations //
 +
- #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
- #define rustg_dmi_create_png(path, width, height, data) call(RUST_G, "dmi_create_png")(path, width, height, data)
- #define rustg_dmi_resize_png(path, width, height, resizetype) call(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
+ #define rustg_dmi_strip_metadata(fname) RUSTG_CALL(RUST_G, "dmi_strip_metadata")(fname)
+ #define rustg_dmi_create_png(path, width, height, data) RUSTG_CALL(RUST_G, "dmi_create_png")(path, width, height, data)
+ #define rustg_dmi_resize_png(path, width, height, resizetype) RUSTG_CALL(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
 diff --git a/dmsrc/file.dm b/dmsrc/file.dm
-index cfc3258..1285c79 100644
+index c18d3f8..b285941 100644
 --- a/dmsrc/file.dm
 +++ b/dmsrc/file.dm
 @@ -1,3 +1,5 @@
 +// File Operations //
 +
- #define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
- #define rustg_file_exists(fname) call(RUST_G, "file_exists")(fname)
- #define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
+ #define rustg_file_read(fname) RUSTG_CALL(RUST_G, "file_read")(fname)
+ #define rustg_file_exists(fname) RUSTG_CALL(RUST_G, "file_exists")(fname)
+ #define rustg_file_write(text, fname) RUSTG_CALL(RUST_G, "file_write")(text, fname)
 diff --git a/dmsrc/git.dm b/dmsrc/git.dm
-index 0dc5edc..942e60f 100644
+index b3185db..e718815 100644
 --- a/dmsrc/git.dm
 +++ b/dmsrc/git.dm
 @@ -1,2 +1,4 @@
+-#define rustg_git_revparse(rev) RUSTG_CALL(RUST_G, "rg_git_revparse")(rev)
+-#define rustg_git_commit_date(rev) RUSTG_CALL(RUST_G, "rg_git_commit_date")(rev)
 +// Git Operations //
 +
- #define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
- #define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
++#define rustg_git_revparse(rev) RUSTG_CALL(RUST_G, "rg_git_revparse")(rev)
++#define rustg_git_commit_date(rev) RUSTG_CALL(RUST_G, "rg_git_commit_date")(rev)
 diff --git a/dmsrc/hash.dm b/dmsrc/hash.dm
-index 867b00e..757d58e 100644
+index c666d2e..6354515 100644
 --- a/dmsrc/hash.dm
 +++ b/dmsrc/hash.dm
 @@ -1,3 +1,5 @@
 +// Hashing Functions //
 +
- #define rustg_hash_string(algorithm, text) call(RUST_G, "hash_string")(algorithm, text)
- #define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, fname)
- #define rustg_hash_generate_totp(seed) call(RUST_G, "generate_totp")(seed)
+ #define rustg_hash_string(algorithm, text) RUSTG_CALL(RUST_G, "hash_string")(algorithm, text)
+ #define rustg_hash_file(algorithm, fname) RUSTG_CALL(RUST_G, "hash_file")(algorithm, fname)
+ #define rustg_hash_generate_totp(seed) RUSTG_CALL(RUST_G, "generate_totp")(seed)
 diff --git a/dmsrc/http.dm b/dmsrc/http.dm
-index 93d964b..c1ef9fd 100644
+index d63748d..eba7d68 100644
 --- a/dmsrc/http.dm
 +++ b/dmsrc/http.dm
 @@ -1,3 +1,5 @@
@@ -83,7 +85,7 @@ index 93d964b..c1ef9fd 100644
  #define RUSTG_HTTP_METHOD_PUT "put"
  #define RUSTG_HTTP_METHOD_DELETE "delete"
 diff --git a/dmsrc/jobs.dm b/dmsrc/jobs.dm
-index 499314b..501c20f 100644
+index 499314b..46b95ca 100644
 --- a/dmsrc/jobs.dm
 +++ b/dmsrc/jobs.dm
 @@ -1,3 +1,5 @@
@@ -93,33 +95,32 @@ index 499314b..501c20f 100644
  #define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
  #define RUSTG_JOB_ERROR "JOB PANICKED"
 diff --git a/dmsrc/json.dm b/dmsrc/json.dm
-index 80a1853..b33029a 100644
+index caa637c..c878c33 100644
 --- a/dmsrc/json.dm
 +++ b/dmsrc/json.dm
 @@ -1 +1,3 @@
 +// JSON Operations //
 +
- #define rustg_json_is_valid(text) (call(RUST_G, "json_is_valid")(text) == "true")
+ #define rustg_json_is_valid(text) (RUSTG_CALL(RUST_G, "json_is_valid")(text) == "true")
 diff --git a/dmsrc/log.dm b/dmsrc/log.dm
-index f3be525..4b113a2 100644
+index bbc8fe6..75d6268 100644
 --- a/dmsrc/log.dm
 +++ b/dmsrc/log.dm
 @@ -1,2 +1,4 @@
 +// Logging Operations //
 +
- #define rustg_log_write(fname, text) call(RUST_G, "log_write")(fname, text)
--/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
-+/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
+ #define rustg_log_write(fname, text) RUSTG_CALL(RUST_G, "log_write")(fname, text)
+ /proc/rustg_log_close_all() return RUSTG_CALL(RUST_G, "log_close_all")()
 diff --git a/dmsrc/noise.dm b/dmsrc/noise.dm
-index 6277a46..935356d 100644
+index 5630600..f05e0d3 100644
 --- a/dmsrc/noise.dm
 +++ b/dmsrc/noise.dm
 @@ -1 +1,3 @@
 +// Noise Operations //
 +
- #define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
+ #define rustg_noise_get_at_coordinates(seed, x, y) RUSTG_CALL(RUST_G, "noise_get_at_coordinates")(seed, x, y)
 diff --git a/dmsrc/pathfinder.dm b/dmsrc/pathfinder.dm
-index be5ac80..292aec2 100644
+index 3259aa8..d229569 100644
 --- a/dmsrc/pathfinder.dm
 +++ b/dmsrc/pathfinder.dm
 @@ -1,3 +1,5 @@
@@ -129,7 +130,7 @@ index be5ac80..292aec2 100644
   * Register a list of nodes into a rust library. This list of nodes must have been serialized in a json.
   * Node {// Index of this node in the list of nodes
 diff --git a/dmsrc/redis-pubsub.dm b/dmsrc/redis-pubsub.dm
-index 2524bb5..47e0694 100644
+index 842f1bf..a3c3558 100644
 --- a/dmsrc/redis-pubsub.dm
 +++ b/dmsrc/redis-pubsub.dm
 @@ -1,3 +1,5 @@
@@ -137,58 +138,58 @@ index 2524bb5..47e0694 100644
 +
  #define RUSTG_REDIS_ERROR_CHANNEL "RUSTG_REDIS_ERROR_CHANNEL"
  
- #define rustg_redis_connect(addr) call(RUST_G, "redis_connect")(addr)
+ #define rustg_redis_connect(addr) RUSTG_CALL(RUST_G, "redis_connect")(addr)
 diff --git a/dmsrc/sql.dm b/dmsrc/sql.dm
-index d3bfc49..803dd97 100644
+index cad44b5..d4d3e68 100644
 --- a/dmsrc/sql.dm
 +++ b/dmsrc/sql.dm
 @@ -1,3 +1,5 @@
 +// SQL Operations //
 +
- #define rustg_sql_connect_pool(options) call(RUST_G, "sql_connect_pool")(options)
- #define rustg_sql_query_async(handle, query, params) call(RUST_G, "sql_query_async")(handle, query, params)
- #define rustg_sql_query_blocking(handle, query, params) call(RUST_G, "sql_query_blocking")(handle, query, params)
+ #define rustg_sql_connect_pool(options) RUSTG_CALL(RUST_G, "sql_connect_pool")(options)
+ #define rustg_sql_query_async(handle, query, params) RUSTG_CALL(RUST_G, "sql_query_async")(handle, query, params)
+ #define rustg_sql_query_blocking(handle, query, params) RUSTG_CALL(RUST_G, "sql_query_blocking")(handle, query, params)
 diff --git a/dmsrc/time.dm b/dmsrc/time.dm
-index 56e1b0c..5a76f67 100644
+index f4ac5e5..ca5b686 100644
 --- a/dmsrc/time.dm
 +++ b/dmsrc/time.dm
 @@ -1,3 +1,5 @@
 +// Time Tracking Functions //
 +
- #define rustg_time_microseconds(id) text2num(call(RUST_G, "time_microseconds")(id))
- #define rustg_time_milliseconds(id) text2num(call(RUST_G, "time_milliseconds")(id))
- #define rustg_time_reset(id) call(RUST_G, "time_reset")(id)
+ #define rustg_time_microseconds(id) text2num(RUSTG_CALL(RUST_G, "time_microseconds")(id))
+ #define rustg_time_milliseconds(id) text2num(RUSTG_CALL(RUST_G, "time_milliseconds")(id))
+ #define rustg_time_reset(id) RUSTG_CALL(RUST_G, "time_reset")(id)
 diff --git a/dmsrc/toml.dm b/dmsrc/toml.dm
-index c9a6338..e218b92 100644
+index b490d95..dddce55 100644
 --- a/dmsrc/toml.dm
 +++ b/dmsrc/toml.dm
 @@ -1,3 +1,5 @@
 +// TOML Operations //
 +
- #define rustg_raw_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+ #define rustg_raw_read_toml_file(path) json_decode(RUSTG_CALL(RUST_G, "toml_file_to_json")(path) || "null")
  
  /proc/rustg_read_toml_file(path)
 diff --git a/dmsrc/unzip.dm b/dmsrc/unzip.dm
-index ce945b1..d8be8b1 100644
+index 77e79de..66df598 100644
 --- a/dmsrc/unzip.dm
 +++ b/dmsrc/unzip.dm
 @@ -1,2 +1,4 @@
 +// ZIP File Operations //
 +
- #define rustg_unzip_download_async(url, unzip_directory) call(RUST_G, "unzip_download_async")(url, unzip_directory)
- #define rustg_unzip_check(job_id) call(RUST_G, "unzip_check")("[job_id]")
+ #define rustg_unzip_download_async(url, unzip_directory) RUSTG_CALL(RUST_G, "unzip_download_async")(url, unzip_directory)
+ #define rustg_unzip_check(job_id) RUSTG_CALL(RUST_G, "unzip_check")("[job_id]")
 diff --git a/dmsrc/url.dm b/dmsrc/url.dm
-index b56131b..c83f8aa 100644
+index 3f53e25..a019a13 100644
 --- a/dmsrc/url.dm
 +++ b/dmsrc/url.dm
 @@ -1,3 +1,5 @@
 +// URL Operations //
 +
- #define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
- #define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
+ #define rustg_url_encode(text) RUSTG_CALL(RUST_G, "url_encode")("[text]")
+ #define rustg_url_decode(text) RUSTG_CALL(RUST_G, "url_decode")(text)
  
 diff --git a/dmsrc/worleynoise.dm b/dmsrc/worleynoise.dm
-index 1ff347c..9864a5b 100644
+index 379adfc..ccaa166 100644
 --- a/dmsrc/worleynoise.dm
 +++ b/dmsrc/worleynoise.dm
 @@ -1,3 +1,5 @@
@@ -198,5 +199,5 @@ index 1ff347c..9864a5b 100644
   * This proc generates a noise grid using worley noise algorithm
   *
 -- 
-2.17.1
+2.35.2.windows.1
 

--- a/paradise-rust-g-patches/0004-Paradise-DLL-Location-Fix.patch
+++ b/paradise-rust-g-patches/0004-Paradise-DLL-Location-Fix.patch
@@ -1,11 +1,11 @@
-From 9205943c2ead317cd6451ea9e4f0372685e8d2bb Mon Sep 17 00:00:00 2001
+From 6b7699bf39674cd6f84eb90662bad77247343b21 Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Wed, 13 Oct 2021 22:16:17 +0100
 Subject: [PATCH] Paradise DLL Location Fix
 
 
 diff --git a/dmsrc/main.dm b/dmsrc/main.dm
-index bd4497a..23afef1 100644
+index bd4497a..35c1c72 100644
 --- a/dmsrc/main.dm
 +++ b/dmsrc/main.dm
 @@ -33,7 +33,7 @@
@@ -18,5 +18,5 @@ index bd4497a..23afef1 100644
  #define RUST_G (__rust_g || __detect_rust_g())
  #endif
 -- 
-2.33.0.windows.2
+2.17.1
 

--- a/paradise-rust-g-patches/0005-Paradise-HTTP-Module-Tweaks.patch
+++ b/paradise-rust-g-patches/0005-Paradise-HTTP-Module-Tweaks.patch
@@ -1,11 +1,11 @@
-From 9a11463e8917f08504ba270f8c0ed07c204840e4 Mon Sep 17 00:00:00 2001
+From 81098ac672c0e1f44dfb7d511453439c4799ed54 Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Thu, 14 Oct 2021 15:50:14 +0100
 Subject: [PATCH] Paradise HTTP Module Tweaks
 
 
 diff --git a/dmsrc/http.dm b/dmsrc/http.dm
-index eba7d68..042522f 100644
+index eba7d68..fdcf7a7 100644
 --- a/dmsrc/http.dm
 +++ b/dmsrc/http.dm
 @@ -1,5 +1,5 @@
@@ -20,8 +20,8 @@ index eba7d68..042522f 100644
  #define rustg_http_request_blocking(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_blocking")(method, url, body, headers, options)
  #define rustg_http_request_async(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_async")(method, url, body, headers, options)
  #define rustg_http_check_request(req_id) RUSTG_CALL(RUST_G, "http_check_request")(req_id)
-+/proc/rustg_create_async_http_client() return call(RUST_G, "start_http_client")()
-+/proc/rustg_close_async_http_client() return call(RUST_G, "shutdown_http_client")()
++/proc/rustg_create_async_http_client() return RUSTG_CALL(RUST_G, "start_http_client")()
++/proc/rustg_close_async_http_client() return RUSTG_CALL(RUST_G, "shutdown_http_client")()
 diff --git a/src/http.rs b/src/http.rs
 index 5da2ff1..426f869 100644
 --- a/src/http.rs

--- a/paradise-rust-g-patches/0005-Paradise-HTTP-Module-Tweaks.patch
+++ b/paradise-rust-g-patches/0005-Paradise-HTTP-Module-Tweaks.patch
@@ -1,17 +1,25 @@
-From 38e84cfb002ed5a405ec2cb126388562e174130c Mon Sep 17 00:00:00 2001
+From 9a11463e8917f08504ba270f8c0ed07c204840e4 Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Thu, 14 Oct 2021 15:50:14 +0100
 Subject: [PATCH] Paradise HTTP Module Tweaks
 
 
 diff --git a/dmsrc/http.dm b/dmsrc/http.dm
-index c1ef9fd..38ef9d2 100644
+index eba7d68..042522f 100644
 --- a/dmsrc/http.dm
 +++ b/dmsrc/http.dm
+@@ -1,5 +1,5 @@
+-// HTTP Operations //
+-
++// HTTP Operations //
++
+ #define RUSTG_HTTP_METHOD_GET "get"
+ #define RUSTG_HTTP_METHOD_PUT "put"
+ #define RUSTG_HTTP_METHOD_DELETE "delete"
 @@ -9,3 +9,5 @@
- #define rustg_http_request_blocking(method, url, body, headers, options) call(RUST_G, "http_request_blocking")(method, url, body, headers, options)
- #define rustg_http_request_async(method, url, body, headers, options) call(RUST_G, "http_request_async")(method, url, body, headers, options)
- #define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
+ #define rustg_http_request_blocking(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_blocking")(method, url, body, headers, options)
+ #define rustg_http_request_async(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_async")(method, url, body, headers, options)
+ #define rustg_http_check_request(req_id) RUSTG_CALL(RUST_G, "http_check_request")(req_id)
 +/proc/rustg_create_async_http_client() return call(RUST_G, "start_http_client")()
 +/proc/rustg_close_async_http_client() return call(RUST_G, "shutdown_http_client")()
 diff --git a/src/http.rs b/src/http.rs
@@ -166,5 +174,5 @@ index 16b5009..9b5d5c5 100644
          req,
          unzip_directory: dir_copy,
 -- 
-2.17.1
+2.35.2.windows.1
 

--- a/paradise-rust-g-patches/0005-Paradise-HTTP-Module-Tweaks.patch
+++ b/paradise-rust-g-patches/0005-Paradise-HTTP-Module-Tweaks.patch
@@ -1,14 +1,14 @@
-From 8a6dadb046618da8cbd32d6651d3e27d36da9d9d Mon Sep 17 00:00:00 2001
+From 38e84cfb002ed5a405ec2cb126388562e174130c Mon Sep 17 00:00:00 2001
 From: AffectedArc07 <25063394+AffectedArc07@users.noreply.github.com>
 Date: Thu, 14 Oct 2021 15:50:14 +0100
 Subject: [PATCH] Paradise HTTP Module Tweaks
 
 
 diff --git a/dmsrc/http.dm b/dmsrc/http.dm
-index e74e6d0..ba37ab3 100644
+index c1ef9fd..38ef9d2 100644
 --- a/dmsrc/http.dm
 +++ b/dmsrc/http.dm
-@@ -8,3 +8,5 @@
+@@ -9,3 +9,5 @@
  #define rustg_http_request_blocking(method, url, body, headers, options) call(RUST_G, "http_request_blocking")(method, url, body, headers, options)
  #define rustg_http_request_async(method, url, body, headers, options) call(RUST_G, "http_request_async")(method, url, body, headers, options)
  #define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
@@ -166,5 +166,5 @@ index 16b5009..9b5d5c5 100644
          req,
          unzip_directory: dir_copy,
 -- 
-2.33.0.windows.2
+2.17.1
 


### PR DESCRIPTION
This PR bumps rust-g to 1.2.0, as well as overhauling the patching logic to use version tags instead of just a commit in a submodule, because submodules are jank.

Fixes #4
Fixes #5

Release will come later. DNM. 

