### PR TITLE
fix: Unknown revision if you have an outdated tg repository

### DIFF
--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -13,6 +13,7 @@ fi
 echo "Setting up project... "
 
 cd "$basedir/tg-rust-g"
+git fetch
 git reset --hard $tg_tag
 
 apply_patch() {


### PR DESCRIPTION
If you already have the repository, you need to update it, otherwise the 3.4.0 tag may not be there.